### PR TITLE
Add 40Hz tick-accurate logic simulator

### DIFF
--- a/src/sm_blueprint_lib/__init__.py
+++ b/src/sm_blueprint_lib/__init__.py
@@ -17,4 +17,12 @@ from .rot import *
 from .bases import *
 from .blocks import *
 
-from .preview import *
+# The 3D preview module pulls in pygame / moderngl / imgui. Make it optional
+# so headless use cases (e.g. running the simulator in CI) don't require the
+# graphics stack to be installed.
+try:
+    from .preview import *
+except ImportError:
+    pass
+
+from .simulator import Simulator, MutualGateConnectionError

--- a/src/sm_blueprint_lib/simulator/__init__.py
+++ b/src/sm_blueprint_lib/simulator/__init__.py
@@ -1,0 +1,23 @@
+"""Synchronous 40Hz logic simulator for Scrap Mechanic blueprints.
+
+Usage:
+    from sm_blueprint_lib import Blueprint, LogicGate, Timer, connect
+    from sm_blueprint_lib.simulator import Simulator
+
+    bp = Blueprint()
+    a = LogicGate(pos=(0,0,0), controller="and")
+    b = LogicGate(pos=(1,0,0), controller="or")
+    connect(a, b)
+    bp.add(a, b)
+
+    sim = Simulator(bp)
+    sim.set(a, True)
+    sim.tick(2)            # advance 2 game ticks (1/20th of a second)
+    print(sim.get(b))      # -> True
+
+The simulator is independent of the optional 3D `preview` module — importing
+it does not pull in pygame / moderngl.
+"""
+from .simulator import Simulator, MutualGateConnectionError
+
+__all__ = ["Simulator", "MutualGateConnectionError"]

--- a/src/sm_blueprint_lib/simulator/simulator.py
+++ b/src/sm_blueprint_lib/simulator/simulator.py
@@ -1,0 +1,271 @@
+"""Tick-accurate logic simulator for Scrap Mechanic blueprints.
+
+Scrap Mechanic runs logic at 40 ticks per second. On every tick each logic
+gate reads its current inputs, computes its next state, and all gates commit
+simultaneously. This gives every gate a one-tick propagation delay and makes
+the network synchronous (double-buffered).
+
+Key rules enforced:
+    * Two distinct ``LogicGate`` parts cannot be wired into each other (i.e.
+      ``A -> B`` and ``B -> A`` simultaneously). Attempting to construct a
+      :class:`Simulator` over such a blueprint raises
+      :class:`MutualGateConnectionError`.
+    * A logic gate may be wired into itself (``A -> A``); this is the standard
+      Scrap Mechanic way to build a 1-tick toggle from a NAND/NOR with a single
+      input.
+
+The simulator does not require the optional ``preview`` dependencies
+(pygame / moderngl); it operates purely on the blueprint dataclass tree.
+"""
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+from ..blueprint import Blueprint
+from ..parts.interactive import Button, LogicGate, Sensor, Switch, Timer
+
+# Logic gate mode codes, matching ``LogicGateController``.
+_AND, _OR, _XOR, _NAND, _NOR, _XNOR = range(6)
+
+# Scrap Mechanic logic tick rate.
+TICKS_PER_SECOND = 40
+
+
+class MutualGateConnectionError(ValueError):
+    """Raised when two distinct logic gates are wired into each other."""
+
+
+def _resolve_id(ref) -> int:
+    """Return the integer id from an ``ID`` instance or a raw int."""
+    return ref.id if hasattr(ref, "id") else int(ref)
+
+
+class Simulator:
+    """Synchronous 40Hz logic simulator.
+
+    Parameters
+    ----------
+    bp:
+        The blueprint to simulate. Parts are discovered by walking
+        ``bp.all_parts()``.
+    validate:
+        If ``True`` (default), refuse to simulate blueprints containing
+        mutual gate connections (Scrap Mechanic disallows them). Set to
+        ``False`` to bypass the check; the simulator will still run but the
+        outputs are not what the game would produce.
+    """
+
+    def __init__(self, bp: Blueprint, *, validate: bool = True):
+        self.bp = bp
+
+        # cid -> part instance
+        self._parts: dict[int, object] = {}
+        # cid -> current active state
+        self._state: dict[int, bool] = {}
+        # cid -> next-state buffer (reused each tick to avoid allocation)
+        self._next: dict[int, bool] = {}
+        # cid -> list of upstream cids feeding into this part
+        self._inputs: dict[int, list[int]] = {}
+        # cid -> deque of length=delay holding past inputs (timers only)
+        self._timer_queues: dict[int, deque[bool]] = {}
+        # cids whose state is held manually via set() and not auto-evaluated
+        self._pinned: set[int] = set()
+        self._tick_count = 0
+
+        self._build()
+        if validate:
+            self._validate_no_mutual_gate_connections()
+
+    # ------------------------------------------------------------------ build
+
+    def _build(self) -> None:
+        for part in self.bp.all_parts():
+            controller = getattr(part, "controller", None)
+            if controller is None:
+                continue
+            cid = getattr(controller, "id", None)
+            if cid is None:
+                continue
+            self._parts[cid] = part
+            self._inputs[cid] = []
+            self._state[cid] = bool(getattr(controller, "active", False))
+
+        # Reverse adjacency: A.controller.controllers lists A's outputs.
+        for cid, part in self._parts.items():
+            for ref in (part.controller.controllers or ()):
+                target = _resolve_id(ref)
+                if target in self._inputs:
+                    self._inputs[target].append(cid)
+
+        for cid, part in self._parts.items():
+            if isinstance(part, Timer):
+                delay_ticks = (
+                    part.controller.seconds * TICKS_PER_SECOND
+                    + part.controller.ticks
+                )
+                # A delay of 0 still uses a length-1 buffer so the timer has
+                # the same one-tick propagation behavior as a logic gate.
+                length = max(1, delay_ticks)
+                seed = bool(getattr(part.controller, "active", False))
+                self._timer_queues[cid] = deque([seed] * length, maxlen=length)
+
+    def _validate_no_mutual_gate_connections(self) -> None:
+        for cid, part in self._parts.items():
+            if not isinstance(part, LogicGate):
+                continue
+            outs = part.controller.controllers or ()
+            for ref in outs:
+                target_id = _resolve_id(ref)
+                if target_id == cid:
+                    continue  # self-loop is allowed
+                target = self._parts.get(target_id)
+                if not isinstance(target, LogicGate):
+                    continue
+                target_outs = target.controller.controllers or ()
+                if any(_resolve_id(t) == cid for t in target_outs):
+                    raise MutualGateConnectionError(
+                        f"Mutual logic-gate connection between gate id={cid} "
+                        f"and gate id={target_id}. Scrap Mechanic does not "
+                        f"allow two distinct logic gates wired into each "
+                        f"other; self-loops (gate -> itself) are fine."
+                    )
+
+    # --------------------------------------------------------------- public API
+
+    @property
+    def tick_count(self) -> int:
+        """Number of ticks simulated so far."""
+        return self._tick_count
+
+    def set(self, part, value: bool) -> None:
+        """Pin a part's output state to ``value`` and stop auto-evaluating it.
+
+        Use for any part you want to drive externally — Buttons, Switches,
+        Sensors, but also gates if you're hand-stepping a sub-circuit.
+        """
+        cid = part.controller.id
+        if cid not in self._state:
+            raise KeyError(f"part with controller id {cid} is not in this blueprint")
+        self._state[cid] = bool(value)
+        self._pinned.add(cid)
+
+    def unpin(self, part) -> None:
+        """Resume auto-evaluating ``part`` after a previous :meth:`set`."""
+        self._pinned.discard(part.controller.id)
+
+    def get(self, part) -> bool:
+        """Return the current active state of ``part`` (after the last tick)."""
+        return self._state[part.controller.id]
+
+    def press(self, part, hold_ticks: int = 1) -> None:
+        """Pulse ``part`` ON for ``hold_ticks`` ticks, then release to OFF.
+
+        Convenience for Button / Switch interactions: drives the part true,
+        advances the simulation, then drives it false. The part is left in
+        the pinned state so it stays OFF until you :meth:`set` it again.
+        """
+        if hold_ticks < 1:
+            raise ValueError("hold_ticks must be >= 1")
+        self.set(part, True)
+        self.tick(hold_ticks)
+        self.set(part, False)
+
+    def tick(self, n: int = 1) -> None:
+        """Advance the simulation by ``n`` ticks (default 1)."""
+        for _ in range(n):
+            self._step()
+
+    def run(self, *, ticks: int = 0, seconds: float = 0.0) -> None:
+        """Advance ``ticks + seconds*40`` ticks total."""
+        total = ticks + int(round(seconds * TICKS_PER_SECOND))
+        self.tick(total)
+
+    def state(self) -> dict[int, bool]:
+        """Snapshot of every part's current active state, keyed by controller id."""
+        return dict(self._state)
+
+    def inputs_of(self, part) -> list[bool]:
+        """Return the current active states of all parts feeding into ``part``."""
+        cid = part.controller.id
+        return [self._state[i] for i in self._inputs[cid]]
+
+    # ------------------------------------------------------------------ step
+
+    def _step(self) -> None:
+        state = self._state
+        nxt = self._next
+        inputs_map = self._inputs
+        pinned = self._pinned
+        timer_queues = self._timer_queues
+
+        # Phase 1: compute next state from CURRENT state. We never read from
+        # nxt during this phase, so the update is fully synchronous.
+        for cid, part in self._parts.items():
+            if cid in pinned:
+                nxt[cid] = state[cid]
+                continue
+
+            if isinstance(part, LogicGate):
+                ins = inputs_map[cid]
+                if not ins:
+                    # Unconnected gate: hold its current state.
+                    nxt[cid] = state[cid]
+                else:
+                    nxt[cid] = _eval_gate(part.controller.mode, ins, state)
+                continue
+
+            if isinstance(part, Timer):
+                q = timer_queues[cid]
+                input_val = any(state[i] for i in inputs_map[cid])
+                # Push first so the queue holds the most recent `delay` inputs.
+                # Then read the oldest of those — i.e. the input from `delay`
+                # ticks ago — so total propagation delay equals the queue's
+                # configured length (one tick for a length-1 queue, matching
+                # a normal logic gate).
+                q.append(input_val)  # maxlen evicts the front automatically
+                nxt[cid] = q[0]
+                continue
+
+            if isinstance(part, (Switch, Button, Sensor)):
+                # External input parts default to "hold" — the only way they
+                # change is through .set(). This matches game semantics where
+                # a switch's state isn't driven by other gates.
+                nxt[cid] = state[cid]
+                continue
+
+            # Passive sinks (lights, engines, pistons, ...): their "active"
+            # output is the OR of incoming signals, mirroring how the game
+            # turns a connected light on when any wire is hot.
+            ins = inputs_map[cid]
+            if ins:
+                nxt[cid] = any(state[i] for i in ins)
+            else:
+                nxt[cid] = state[cid]
+
+        # Phase 2: commit.
+        state.update(nxt)
+        self._tick_count += 1
+
+
+def _eval_gate(mode: int, input_cids: Iterable[int], state: dict[int, bool]) -> bool:
+    """Evaluate a logic-gate mode against the given input ids' active states."""
+    n = 0
+    n_true = 0
+    for i in input_cids:
+        n += 1
+        if state[i]:
+            n_true += 1
+    if mode == _AND:
+        return n_true == n
+    if mode == _OR:
+        return n_true > 0
+    if mode == _XOR:
+        return n_true % 2 == 1
+    if mode == _NAND:
+        return n_true != n
+    if mode == _NOR:
+        return n_true == 0
+    if mode == _XNOR:
+        return n_true % 2 == 0
+    return False

--- a/src/tests/test_simulator.py
+++ b/src/tests/test_simulator.py
@@ -1,0 +1,272 @@
+"""Tests for the 40-tick logic simulator.
+
+Run from the repo root:
+
+    python src/tests/test_simulator.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # repo/src
+
+import sm_blueprint_lib as sm
+from sm_blueprint_lib.simulator import Simulator, MutualGateConnectionError
+
+
+# ---------------------------------------------------------------------- helpers
+
+def _make(gates_spec):
+    """Quick way to build a blueprint with named LogicGates.
+
+    ``gates_spec`` is a dict ``{name: mode}``. Returns ``(bp, parts_by_name)``.
+    """
+    bp = sm.Blueprint()
+    parts = {}
+    for i, (name, mode) in enumerate(gates_spec.items()):
+        parts[name] = sm.LogicGate(pos=(i, 0, 0), color="ffffff", controller=mode)
+    bp.add(*parts.values())
+    return bp, parts
+
+
+def assert_eq(actual, expected, msg=""):
+    if actual != expected:
+        raise AssertionError(f"{msg}: expected {expected!r}, got {actual!r}")
+
+
+# ---------------------------------------------------------------------- tests
+
+def test_propagation_delay_is_one_tick_per_gate():
+    """A high signal driven into A should reach C exactly two ticks later
+    when the chain is A -> B -> C."""
+    bp, p = _make({"a": "or", "b": "or", "c": "or"})
+    sm.connect(p["a"], p["b"])
+    sm.connect(p["b"], p["c"])
+
+    s = Simulator(bp)
+    s.set(p["a"], True)
+
+    # tick 0: a is on (just set), b and c still off (haven't read yet)
+    assert_eq(s.get(p["a"]), True, "a after set")
+    assert_eq(s.get(p["b"]), False, "b before any tick")
+    assert_eq(s.get(p["c"]), False, "c before any tick")
+
+    s.tick()  # tick 1
+    assert_eq(s.get(p["b"]), True, "b after 1 tick")
+    assert_eq(s.get(p["c"]), False, "c after 1 tick")
+
+    s.tick()  # tick 2
+    assert_eq(s.get(p["c"]), True, "c after 2 ticks")
+
+
+def test_basic_gate_truth_tables():
+    """All six gate modes evaluate correctly with two driven inputs."""
+    cases = [
+        ("and",  [(0, 0, False), (1, 0, False), (0, 1, False), (1, 1, True)]),
+        ("or",   [(0, 0, False), (1, 0, True),  (0, 1, True),  (1, 1, True)]),
+        ("xor",  [(0, 0, False), (1, 0, True),  (0, 1, True),  (1, 1, False)]),
+        ("nand", [(0, 0, True),  (1, 0, True),  (0, 1, True),  (1, 1, False)]),
+        ("nor",  [(0, 0, True),  (1, 0, False), (0, 1, False), (1, 1, False)]),
+        ("xnor", [(0, 0, True),  (1, 0, False), (0, 1, False), (1, 1, True)]),
+    ]
+    for mode, table in cases:
+        for a_val, b_val, expected in table:
+            bp = sm.Blueprint()
+            a = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="or")
+            b = sm.LogicGate(pos=(0, 0, 1), color="ff0000", controller="or")
+            g = sm.LogicGate(pos=(0, 0, 2), color="ff0000", controller=mode)
+            sm.connect(a, g)
+            sm.connect(b, g)
+            bp.add(a, b, g)
+
+            sim = Simulator(bp)
+            sim.set(a, bool(a_val))
+            sim.set(b, bool(b_val))
+            sim.tick()  # one tick is enough — a/b are pinned, g reads them
+            assert_eq(
+                sim.get(g), expected,
+                f"{mode}({a_val},{b_val})"
+            )
+
+
+def test_self_loop_nand_oscillates_every_tick():
+    """A NAND gate fed from itself should toggle on every tick (1-tick clock).
+    This is the canonical Scrap Mechanic 'NOT itself' clock pattern."""
+    bp = sm.Blueprint()
+    g = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="nand")
+    sm.connect(g, g)
+    bp.add(g)
+
+    sim = Simulator(bp)
+    # Initial state is False; NAND of a single False input is True, so the
+    # gate flips True on tick 1, False on tick 2, True on tick 3, ...
+    expected = [True, False, True, False, True, False]
+    for i, want in enumerate(expected, start=1):
+        sim.tick()
+        assert_eq(sim.get(g), want, f"tick {i}")
+
+
+def test_mutual_gate_connection_is_rejected():
+    """A->B and B->A between two distinct LogicGates is a hard error."""
+    bp, p = _make({"a": "or", "b": "or"})
+    sm.connect(p["a"], p["b"])
+    sm.connect(p["b"], p["a"])
+
+    raised = False
+    try:
+        Simulator(bp)
+    except MutualGateConnectionError:
+        raised = True
+    if not raised:
+        raise AssertionError("expected MutualGateConnectionError but none raised")
+
+
+def test_self_loop_is_allowed_even_though_mutual_gates_arent():
+    """Self-loop should pass validation."""
+    bp = sm.Blueprint()
+    g = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="nand")
+    sm.connect(g, g)
+    bp.add(g)
+    Simulator(bp)  # should not raise
+
+
+def test_timer_delays_signal_by_configured_ticks():
+    """A timer with delay (0, 5) delays its input by 5 ticks."""
+    bp = sm.Blueprint()
+    src = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="or")
+    t = sm.Timer(pos=(0, 0, 1), color="000000", controller=(0, 5))
+    sink = sm.LogicGate(pos=(0, 0, 2), color="00ff00", controller="or")
+    sm.connect(src, t)
+    sm.connect(t, sink)
+    bp.add(src, t, sink)
+
+    sim = Simulator(bp)
+    sim.set(src, True)
+
+    # The signal must flow: src (pinned) -> timer (5-tick delay) -> sink (1-tick gate).
+    # So sink should turn on at tick 5+1 = tick 6 in our model. Verify timer
+    # output first, then the sink one tick later.
+    for tick_no in range(1, 6):
+        sim.tick()
+        # Timer output is the value pushed `delay` ticks ago — initial False.
+        # On the 5th tick, the True we pushed at tick 1 reaches the front.
+    # After 5 ticks the timer output should be True.
+    assert_eq(
+        any(sim.get(t) for _ in [0]),  # silly OR to keep linter happy
+        True,
+        "timer output after 5 ticks",
+    )
+    sim.tick()  # +1 for sink propagation
+    assert_eq(sim.get(sink), True, "sink after timer + 1 gate delay")
+
+
+def test_timer_one_second_delay():
+    """delay=(1, 0) is exactly 40 ticks."""
+    bp = sm.Blueprint()
+    src = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="or")
+    t = sm.Timer(pos=(0, 0, 1), color="000000", controller=(1, 0))
+    sm.connect(src, t)
+    bp.add(src, t)
+
+    sim = Simulator(bp)
+    sim.set(src, True)
+
+    # 39 ticks: timer still off
+    sim.tick(39)
+    assert_eq(sim.get(t), False, "timer still off at tick 39")
+    sim.tick()
+    assert_eq(sim.get(t), True, "timer on at tick 40")
+
+
+def test_synchronous_update_chain_does_not_propagate_in_one_tick():
+    """In SM, a chain of N gates takes N ticks for a signal to traverse — they
+    don't all evaluate in topological order in a single tick."""
+    bp = sm.Blueprint()
+    chain = [sm.LogicGate(pos=(i, 0, 0), color="ffffff", controller="or") for i in range(5)]
+    for i in range(len(chain) - 1):
+        sm.connect(chain[i], chain[i + 1])
+    bp.add(*chain)
+
+    sim = Simulator(bp)
+    sim.set(chain[0], True)
+    # After 1 tick only chain[1] should have flipped.
+    sim.tick()
+    states = [sim.get(g) for g in chain]
+    assert_eq(states, [True, True, False, False, False], "after 1 tick")
+    sim.tick()
+    assert_eq([sim.get(g) for g in chain], [True, True, True, False, False], "after 2 ticks")
+    sim.tick(2)
+    assert_eq([sim.get(g) for g in chain], [True, True, True, True, True], "after 4 ticks")
+
+
+def test_set_overrides_inputs():
+    """Pinning a part with set() prevents auto-evaluation even with inputs."""
+    bp = sm.Blueprint()
+    src = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="or")
+    sink = sm.LogicGate(pos=(1, 0, 0), color="ff0000", controller="or")
+    sm.connect(src, sink)
+    bp.add(src, sink)
+
+    sim = Simulator(bp)
+    sim.set(src, True)
+    sim.set(sink, False)  # pin sink off despite incoming True signal
+    sim.tick(5)
+    assert_eq(sim.get(sink), False, "sink stays pinned off")
+
+    sim.unpin(sink)
+    sim.tick()
+    assert_eq(sim.get(sink), True, "sink picks up input after unpin")
+
+
+def test_3_input_xor():
+    """XOR with three inputs: true iff odd number of inputs are true."""
+    bp = sm.Blueprint()
+    a = sm.LogicGate(pos=(0, 0, 0), color="ff0000", controller="or")
+    b = sm.LogicGate(pos=(0, 0, 1), color="ff0000", controller="or")
+    c = sm.LogicGate(pos=(0, 0, 2), color="ff0000", controller="or")
+    g = sm.LogicGate(pos=(1, 0, 0), color="00ff00", controller="xor")
+    sm.connect(a, g); sm.connect(b, g); sm.connect(c, g)
+    bp.add(a, b, c, g)
+
+    for mask in range(8):
+        sim = Simulator(bp)
+        sim.set(a, bool(mask & 1))
+        sim.set(b, bool(mask & 2))
+        sim.set(c, bool(mask & 4))
+        sim.tick()
+        bits = bin(mask).count("1")
+        assert_eq(sim.get(g), bits % 2 == 1, f"xor mask={mask:03b}")
+
+
+# ---------------------------------------------------------------------- runner
+
+def main():
+    tests = [
+        ("propagation_delay_is_one_tick_per_gate", test_propagation_delay_is_one_tick_per_gate),
+        ("basic_gate_truth_tables", test_basic_gate_truth_tables),
+        ("self_loop_nand_oscillates_every_tick", test_self_loop_nand_oscillates_every_tick),
+        ("mutual_gate_connection_is_rejected", test_mutual_gate_connection_is_rejected),
+        ("self_loop_is_allowed_even_though_mutual_gates_arent", test_self_loop_is_allowed_even_though_mutual_gates_arent),
+        ("timer_delays_signal_by_configured_ticks", test_timer_delays_signal_by_configured_ticks),
+        ("timer_one_second_delay", test_timer_one_second_delay),
+        ("synchronous_update_chain_does_not_propagate_in_one_tick", test_synchronous_update_chain_does_not_propagate_in_one_tick),
+        ("set_overrides_inputs", test_set_overrides_inputs),
+        ("3_input_xor", test_3_input_xor),
+    ]
+    failures = []
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as e:
+            failures.append((name, str(e)))
+            print(f"FAIL {name}: {e}")
+        else:
+            print(f"ok   {name}")
+    print()
+    if failures:
+        print(f"{len(failures)} / {len(tests)} test(s) failed")
+        sys.exit(1)
+    print(f"all {len(tests)} tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `sm_blueprint_lib.simulator.Simulator`: a synchronous double-buffered evaluator that mirrors Scrap Mechanic's 40 Hz logic runtime. Each tick every part reads its current inputs, computes its next state, and all states commit together — so every gate has exactly one tick of propagation delay.
- Refuses to simulate blueprints where two distinct `LogicGate` parts are wired into each other (Scrap Mechanic disallows this). Self-loops (`A -> A`) are preserved for the canonical NAND-on-itself 1-tick clock.
- Supports `LogicGate` (and/or/xor/nand/nor/xnor), `Timer` (delay queue sized in ticks), `Switch` / `Button` / `Sensor` as user-driven inputs via `sim.set(part, value)`, and passive sinks (lights, engines, …) as OR-of-inputs so you can read out whether your circuit lit a light.
- Makes the optional 3D preview import in the package `__init__` non-fatal, so the simulator can be used in headless environments without pygame / moderngl / imgui installed.

## API
```python
from sm_blueprint_lib import Blueprint, LogicGate, connect
from sm_blueprint_lib.simulator import Simulator

bp = Blueprint()
a = LogicGate(pos=(0,0,0), color="ff0000", controller="or")
b = LogicGate(pos=(1,0,0), color="ff0000", controller="nand")
connect(a, b); bp.add(a, b)

sim = Simulator(bp)
sim.set(a, True)
sim.tick(2)
print(sim.get(b))   # -> False  (NAND of True)
```

## Test plan
- [x] Gate truth tables for and/or/xor/nand/nor/xnor with two inputs
- [x] 5-gate chain — signal advances exactly one gate per tick
- [x] NAND self-loop toggles every tick (1-tick clock)
- [x] Mutual gate connection raises `MutualGateConnectionError`
- [x] Self-loop passes validation
- [x] Timer with 5-tick delay outputs 5 ticks after input
- [x] Timer with 1-second delay (40 ticks) — off at tick 39, on at tick 40
- [x] `set()` pins a part's state until `unpin()`
- [x] 3-input XOR for all 8 input combinations

Run: `python src/tests/test_simulator.py` — all 10 tests pass.